### PR TITLE
Fix helloTarget_standard test

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/com/praqma/demo/greeting/GreetingModuleTest.groovy
+++ b/src/test/groovy/com/praqma/demo/greeting/GreetingModuleTest.groovy
@@ -67,7 +67,7 @@ class GreetingModuleTest {
         def result = gradle('helloTarget')
 
         assert result.task(":helloTarget").outcome == SUCCESS
-        assert result.output.contains("Hello, user!")
+        assert result.output.contains("Hello, default-user!")
     }
 
     @Test


### PR DESCRIPTION
The default user was changed in commit e68518226ec734788bb531801f576ba8b4b7cc8d,
but the tests were not updated to match, so they do not pass.